### PR TITLE
Fix type safety issues, event listener memory leak, code duplication,…

### DIFF
--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -31,15 +31,37 @@ router.post('/test-payload', (req, res) => {
 });
 
 
-// Chunk-based map generation endpoint - new primary method
+function handleChunkRequest(chunkX: number, chunkY: number, seed: string, res: import('express').Response) {
+  const request: MapChunkRequest = { chunkX, chunkY, seed };
+
+  console.log(`[Chunk Map] Request: chunkX=${chunkX}, chunkY=${chunkY}, seed=${seed} (16x16 chunk)`);
+
+  validateMapChunkRequest(request);
+
+  const startTime = Date.now();
+  const response = generateMapChunk(request);
+  const duration = Date.now() - startTime;
+
+  console.log(`[Chunk Map] Generated chunk (${chunkX}, ${chunkY}) in ${duration}ms, size: ${Math.round(response.sizeBytes / 1024)}KB`);
+
+  if (response.sizeBytes > 6 * 1024 * 1024) {
+    const error: ApiError = {
+      error: 'Payload too large',
+      details: `Generated ${Math.round(response.sizeBytes / 1024 / 1024 * 100) / 100}MB, exceeds 6MB limit`
+    };
+    return res.status(413).json(error);
+  }
+
+  return res.json(response);
+}
+
+// Chunk-based map generation endpoint - GET
 router.get('/chunk', (req, res) => {
   try {
-    // Parse query parameters - chunkX, chunkY, and seed
     const chunkX = parseInt(req.query.chunkX as string);
     const chunkY = parseInt(req.query.chunkY as string);
-    const seed = req.query.seed as string || 'default';
+    const seed = (req.query.seed as string) || 'default';
 
-    // Validate numeric inputs
     if (isNaN(chunkX) || isNaN(chunkY)) {
       const error: ApiError = {
         error: 'Invalid chunk coordinates',
@@ -48,35 +70,7 @@ router.get('/chunk', (req, res) => {
       return res.status(400).json(error);
     }
 
-    const request: MapChunkRequest = {
-      chunkX,
-      chunkY,
-      seed
-    };
-
-    console.log(`[Chunk Map] Request: chunkX=${chunkX}, chunkY=${chunkY}, seed=${seed} (16x16 chunk)`);
-
-    // Validate request
-    validateMapChunkRequest(request);
-
-    // Generate the requested chunk
-    const startTime = Date.now();
-    const response = generateMapChunk(request);
-    const duration = Date.now() - startTime;
-
-    console.log(`[Chunk Map] Generated chunk (${chunkX}, ${chunkY}) in ${duration}ms, size: ${Math.round(response.sizeBytes / 1024)}KB`);
-
-    // Check if payload exceeds 6MB limit (shouldn't happen for single chunks)
-    if (response.sizeBytes > 6 * 1024 * 1024) {
-      const error: ApiError = {
-        error: 'Payload too large',
-        details: `Generated ${Math.round(response.sizeBytes / 1024 / 1024 * 100) / 100}MB, exceeds 6MB limit`
-      };
-      return res.status(413).json(error);
-    }
-
-    res.json(response);
-
+    return handleChunkRequest(chunkX, chunkY, seed, res);
   } catch (error) {
     console.error('[Chunk Map] Error:', error);
     const apiError: ApiError = {
@@ -87,13 +81,11 @@ router.get('/chunk', (req, res) => {
   }
 });
 
-// POST version of chunk endpoint for frontend compatibility
+// Chunk-based map generation endpoint - POST
 router.post('/chunk', (req, res) => {
   try {
-    // Parse POST body - chunkX, chunkY, and seed
     const { chunkX, chunkY, seed = 'default' } = req.body;
 
-    // Validate numeric inputs
     if (typeof chunkX !== 'number' || typeof chunkY !== 'number') {
       const error: ApiError = {
         error: 'Invalid chunk coordinates',
@@ -102,35 +94,7 @@ router.post('/chunk', (req, res) => {
       return res.status(400).json(error);
     }
 
-    const request: MapChunkRequest = {
-      chunkX,
-      chunkY,
-      seed
-    };
-
-    console.log(`[Chunk Map POST] Request: chunkX=${chunkX}, chunkY=${chunkY}, seed=${seed} (16x16 chunk)`);
-
-    // Validate request
-    validateMapChunkRequest(request);
-
-    // Generate the requested chunk
-    const startTime = Date.now();
-    const response = generateMapChunk(request);
-    const duration = Date.now() - startTime;
-
-    console.log(`[Chunk Map POST] Generated chunk (${chunkX}, ${chunkY}) in ${duration}ms, size: ${Math.round(response.sizeBytes / 1024)}KB`);
-
-    // Check if payload exceeds 6MB limit (shouldn't happen for single chunks)
-    if (response.sizeBytes > 6 * 1024 * 1024) {
-      const error: ApiError = {
-        error: 'Payload too large',
-        details: `Generated ${Math.round(response.sizeBytes / 1024 / 1024 * 100) / 100}MB, exceeds 6MB limit`
-      };
-      return res.status(413).json(error);
-    }
-
-    res.json(response);
-
+    return handleChunkRequest(chunkX, chunkY, seed, res);
   } catch (error) {
     console.error('[Chunk Map POST] Error:', error);
     const apiError: ApiError = {

--- a/web/components/app-legend.ts
+++ b/web/components/app-legend.ts
@@ -11,6 +11,8 @@ export class AppLegend extends LitElement {
   // TypeScript property declarations
   declare isCollapsed: boolean;
 
+  private _boundHandleResize!: () => void;
+
   static styles = css`
     :host {
       position: fixed;
@@ -104,27 +106,28 @@ export class AppLegend extends LitElement {
 
   constructor() {
     super();
-    (this as any).isCollapsed = window.innerWidth <= 768;
+    this.isCollapsed = window.innerWidth <= 768;
+    this._boundHandleResize = this._handleResize.bind(this);
   }
 
   connectedCallback() {
     super.connectedCallback();
-    window.addEventListener('resize', this._handleResize.bind(this));
+    window.addEventListener('resize', this._boundHandleResize);
   }
 
   disconnectedCallback() {
     super.disconnectedCallback();
-    window.removeEventListener('resize', this._handleResize.bind(this));
+    window.removeEventListener('resize', this._boundHandleResize);
   }
 
   private _handleResize() {
-    if (window.innerWidth <= 768 && !(this as any).isCollapsed) {
-      (this as any).isCollapsed = true;
+    if (window.innerWidth <= 768 && !this.isCollapsed) {
+      this.isCollapsed = true;
     }
   }
 
   private _toggleLegend() {
-    (this as any).isCollapsed = !(this as any).isCollapsed;
+    this.isCollapsed = !this.isCollapsed;
   }
 
   render() {

--- a/web/components/control-panel.ts
+++ b/web/components/control-panel.ts
@@ -244,13 +244,18 @@ export class ControlPanel extends LitElement {
     const target = event.target as HTMLInputElement;
     const { name, value } = target;
     const numValue = parseInt(value, 10);
-    
-    if (!isNaN(numValue)) {
-      (this as any)[name] = numValue;
-      this.dispatchEvent(new CustomEvent<CoordinateChangeDetail>('coordinate-change', {
-        detail: { [name]: numValue }
-      }));
-    }
+
+    if (isNaN(numValue)) return;
+
+    if (name === 'minX') this.minX = numValue;
+    else if (name === 'maxX') this.maxX = numValue;
+    else if (name === 'minY') this.minY = numValue;
+    else if (name === 'maxY') this.maxY = numValue;
+    else return;
+
+    this.dispatchEvent(new CustomEvent<CoordinateChangeDetail>('coordinate-change', {
+      detail: { [name]: numValue }
+    }));
   }
 
   private _handleWorldNameChange(event: Event) {

--- a/web/components/world-generator.ts
+++ b/web/components/world-generator.ts
@@ -1,6 +1,6 @@
 import { LitElement, html, css } from 'lit';
 import './control-panel.ts';
-import './world-map.ts';
+import { WorldMap } from './world-map.ts';
 
 interface ChunkCoordinate {
   x: number;
@@ -53,7 +53,7 @@ export class WorldGenerator extends LitElement {
   declare statusMessage: string;
   declare chunks: Map<string, ChunkData>;
 
-  worldMap: any;
+  worldMap: WorldMap | null = null;
 
   // Private generation state
   private activeRequests = 0;
@@ -98,9 +98,10 @@ export class WorldGenerator extends LitElement {
 
   private _handleCoordinateChange(event: CustomEvent<CoordinateChangeDetail>) {
     const { detail } = event;
-    Object.keys(detail).forEach(key => {
-      (this as any)[key] = detail[key];
-    });
+    if ('minX' in detail) this.minX = detail['minX'];
+    if ('maxX' in detail) this.maxX = detail['maxX'];
+    if ('minY' in detail) this.minY = detail['minY'];
+    if ('maxY' in detail) this.maxY = detail['maxY'];
   }
 
   private _handleWorldNameChange(event: CustomEvent<WorldNameChangeDetail>) {
@@ -270,13 +271,13 @@ export class WorldGenerator extends LitElement {
     }
   }
 
-  private _getBiomeFromCompactTile(tile: any): string {
-    // Map biome indices to biome names based on BIOME_TYPES from shared/types.ts
+  private _getBiomeFromCompactTile(tile: { b: number; e: number }): string {
+    // Biome names matching BIOME_TYPES order from shared/types.ts
     const biomes = [
       'deep_ocean', 'shallow_ocean', 'desert', 'tundra', 'arctic', 'swamp',
       'grassland', 'forest', 'taiga', 'savanna', 'tropical_forest', 'alpine'
     ];
-    return biomes[tile.b] || 'grassland';
+    return biomes[tile.b] ?? 'grassland';
   }
 
   render() {

--- a/web/components/world-map.ts
+++ b/web/components/world-map.ts
@@ -30,6 +30,8 @@ export class WorldMap extends LitElement {
   canvas!: HTMLCanvasElement;
 
   private context: CanvasRenderingContext2D | null = null;
+  private minChunkX = 0;
+  private minChunkY = 0;
 
   constructor() {
     super();
@@ -136,9 +138,12 @@ export class WorldMap extends LitElement {
   }
 
   setMapSize(minX: number, maxX: number, minY: number, maxY: number) {
+    this.minChunkX = minX;
+    this.minChunkY = minY;
+
     // Ensure canvas is initialized
     this._initializeCanvas();
-    
+
     if (!this.canvas) return;
 
     const widthChunks = maxX - minX + 1;
@@ -226,8 +231,8 @@ export class WorldMap extends LitElement {
   private _renderChunkSimple(chunkX: number, chunkY: number, chunkData: ChunkData) {
     if (!this.context || !chunkData) return;
 
-    const offsetX = chunkX * this.chunkSize * this.tileSize;
-    const offsetY = chunkY * this.chunkSize * this.tileSize;
+    const offsetX = (chunkX - this.minChunkX) * this.chunkSize * this.tileSize;
+    const offsetY = (chunkY - this.minChunkY) * this.chunkSize * this.tileSize;
 
     for (let y = 0; y < this.chunkSize; y++) {
       for (let x = 0; x < this.chunkSize; x++) {


### PR DESCRIPTION
… and rendering offset bug

- app-legend.ts: replace all (this as any) casts with direct property access; fix disconnectedCallback memory leak where bind() created new references that could not be removed by removeEventListener
- router.ts: extract shared handleChunkRequest() to eliminate ~50 lines of duplicated GET/POST chunk handler logic
- world-generator.ts: type worldMap as WorldMap|null instead of any; replace dynamic (this as any) coordinate assignments with explicit named property updates; type compact tile parameter in _getBiomeFromCompactTile
- control-panel.ts: replace (this as any)[name] dynamic assignment with explicit if/else branches for each coordinate property
- world-map.ts: store minChunkX/minChunkY from setMapSize() and apply offsets in _renderChunkSimple() to fix incorrect tile positioning when chunk coordinates are non-zero

https://claude.ai/code/session_014yqzC6rZ5J4cprZNCdwHB5